### PR TITLE
Remove val_gazebo from package.xml.

### DIFF
--- a/launch/valkyrie_ros_api.launch
+++ b/launch/valkyrie_ros_api.launch
@@ -2,7 +2,7 @@
   <param name="use_sim_time" value="true"/>
   <arg name="use_local_build" default="false" />
   <arg name="ihmc_network_file" default="$(find ihmc_valkyrie_ros)/configurations/IHMCNetworkParametersSim.ini" />
-  <arg name="description_model" default="$(find val_description)/model/urdf/valkyrie_sim.urdf" />
+  <arg name="description_model" default="$(find val_description)/model/urdf/valkyrie_A.urdf" />
 
   <include file="$(find ihmc_ros_common)/launch/robot_description_common.launch">
     <arg name="robot_name" value="valkyrie" />

--- a/package.xml
+++ b/package.xml
@@ -22,7 +22,6 @@
   <run_depend>ihmc_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>ihmc_ros_control</run_depend>
-  <run_depend>val_gazebo</run_depend>
   <run_depend>val_description</run_depend>
 
 </package>


### PR DESCRIPTION
Fixes the following error during the rosdep install process:
```
val@link02:~/ihmc_catkin_ws$ rosdep install --from-paths src -i -y
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
ihmc_valkyrie_ros: Cannot locate rosdep definition for [val_gazebo]
```